### PR TITLE
countdown-timer: avoid playing when play prop is false on mount.

### DIFF
--- a/src/components/countdown-timer.js
+++ b/src/components/countdown-timer.js
@@ -17,17 +17,19 @@ class CountdownTimer extends React.Component {
   }
 
   componentDidMount() {
-    const { time } = this.props;
+    const { time, play } = this.props;
     const { hours, minutes, seconds } = TransformUtils.formatNumberToTime(time);
     this.setState({
       hours,
       minutes,
       seconds,
     });
-    this.timer = setInterval(
-      () => this.updateTime(),
-      1000,
-    );
+    if (play) {
+      this.timer = setInterval(
+        () => this.updateTime(),
+        1000,
+      );
+    }
   }
 
   shouldComponentUpdate(nextProps) {


### PR DESCRIPTION
This PR respect the `play` prop given to the countdown timer also on mounting in order to allow rendering paused countdown timer.