### PR TITLE
[BUG] "unit" prop always is overwrited with previous code version. Update countdown-timer.js

### DIFF
--- a/src/components/countdown-timer.js
+++ b/src/components/countdown-timer.js
@@ -60,11 +60,11 @@ class CountdownTimer extends React.Component {
     const { hours, minutes, seconds } = this.state;
     return (
       <View style={[style.wrapper, wrapperStyle]}>
-        {!!hours && <FlipNumber number={hours} unit="hours" {...flipNumberProps} />}
+        {!!hours && <FlipNumber number={hours} {...flipNumberProps} unit="hours" />}
         <Separator />
-        {!!minutes && <FlipNumber number={minutes} unit="minutes" {...flipNumberProps} />}
+        {!!minutes && <FlipNumber number={minutes} {...flipNumberProps} unit="minutes" />}
         <Separator />
-        {!!seconds && <FlipNumber number={seconds} unit="seconds" {...flipNumberProps} />}
+        {!!seconds && <FlipNumber number={seconds} {...flipNumberProps} unit="seconds" />}
       </View>
     );
   }


### PR DESCRIPTION
"unit" prop always is overwrited with previous code version.